### PR TITLE
Add 27W USB-C Power Supply

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,7 @@ Vendor-ID = 0x2E8A
 | 0x000C | Raspberry Pi | Raspberry Pi RP2040 CMSIS-DAP debug adapter |  |
 | 0x000D | Raspberry Pi | Raspberry Pi USB3HUB ( USB2 hub part) |  |
 | 0x000E | Raspberry Pi | Raspberry Pi USB3HUB ( USB3 hub part) |  |
+| 0x000F | Raspberry Pi | Raspberry Pi 27W USB-C Power Supply | [27W USB-C Power Supply](https://www.raspberrypi.com/products/27w-power-supply/) |
 | **Commercial** ||||
 | **0x1000 - 0x1fff** ||||
 | 0x1000 | Cytron Technologies | Cytron Maker Pi RP2040 | https://www.cytron.io/p-maker-pi-rp2040 |


### PR DESCRIPTION
Per https://www.raspberrypi.com/documentation/computers/configuration.html#common-bootloader-properties-chosenbootloader.

See also https://github.com/raspberrypi/documentation/pull/3267.

```
andrew@bookworm5:~ $ od -x  --endian=big /proc/device-tree/chosen/power/rpi_power_supply
0000000 0000 2e8a 000f 0000
0000010
```

Thanks to trejan on the forum: https://forums.raspberrypi.com/viewtopic.php?p=2154632#p2154394.