### PR TITLE
Add RP2040-Tiny

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,3 +152,4 @@ Vendor-ID = 0x2E8A
 | 0x107D | Haute ?cole d'ing?nierie et d'architecture | Picomo | https://go.heia-fr.ch/picomo |
 | 0x107E | Cytron Technologies S/B | Cytron EDU PICO for Pico | https://www.cytron.io/p-edu-project-and-innovation-kit-for-pico-w |
 | 0x107F | x-pantion | Croco Gameboy Cartridge | https://github.com/shilga/rp2040-gameboy-cartridge-firmware |
+| 0x1080 | Waveshare Electronics | RP2040-Tiny | https://www.waveshare.com/rp2040-tiny.htm |


### PR DESCRIPTION
Not affiliated with Waveshare.

Reason for requesting PID:
I'm doing a [CircuitPython board port](https://github.com/adafruit/circuitpython/pull/8796) for it, and that needs a unique pid:vid.