### PR TITLE
New PIDs for RP2350

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,11 +34,13 @@ Vendor-ID = 0x2E8A
 | 0x0003 | Raspberry Pi | Raspberry Pi RP2040 boot | [RP2040](https://www.raspberrypi.com/documentation/microcontrollers/raspberry-pi-pico.html) |
 | 0x0004 | Raspberry Pi | Raspberry Pi PicoProbe | [PicoProbe](https://github.com/raspberrypi/picoprobe/) |
 | 0x0005 | Raspberry Pi | Raspberry Pi Pico MicroPython firmware (CDC) | [MicroPython Firmware](https://micropython.org/download/rp2-pico/) |
-| 0x000A | Raspberry Pi | Raspberry Pi Pico SDK CDC UART | [Raspberry Pi Pico SDK](https://raspberrypi.github.io/pico-sdk-doxygen/index.html) |
+| 0x0009 | Raspberry Pi | Raspberry Pi Pico SDK CDC UART | [Raspberry Pi Pico SDK](https://raspberrypi.github.io/pico-sdk-doxygen/index.html) |
+| 0x000A | Raspberry Pi | Raspberry Pi Pico SDK CDC UART (RP2040) | [Raspberry Pi Pico SDK](https://raspberrypi.github.io/pico-sdk-doxygen/index.html) |
 | 0x000B | Raspberry Pi | Raspberry Pi Pico CircuitPython firmware | [CircuitPython Downloads](https://circuitpython.org/board/raspberry_pi_pico/) |
 | 0x000C | Raspberry Pi | Raspberry Pi RP2040 CMSIS-DAP debug adapter |  |
 | 0x000D | Raspberry Pi | Raspberry Pi USB3HUB ( USB2 hub part) |  |
 | 0x000E | Raspberry Pi | Raspberry Pi USB3HUB ( USB3 hub part) |  |
+| 0x000F | Raspberry Pi | Raspberry Pi RP2350 boot | [RP2350](https://www.raspberrypi.com/documentation/microcontrollers/raspberry-pi-pico.html) |
 | **Commercial** ||||
 | **0x1000 - 0x1fff** ||||
 | 0x1000 | Cytron Technologies | Cytron Maker Pi RP2040 | https://www.cytron.io/p-maker-pi-rp2040 |


### PR DESCRIPTION
Add RP2350 boot PID for RP2350 in bootsel mode

Also add new PID for Pico SDK CDC UART, and rename old one to Pico SDK CDC UART (RP2040)