### PR TITLE
Link directly to Pico-SDK documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,8 +34,8 @@ Vendor-ID = 0x2E8A
 | 0x0003 | Raspberry Pi | Raspberry Pi RP2040 boot | [RP2040](https://www.raspberrypi.com/documentation/microcontrollers/raspberry-pi-pico.html) |
 | 0x0004 | Raspberry Pi | Raspberry Pi PicoProbe | [PicoProbe](https://github.com/raspberrypi/picoprobe/) |
 | 0x0005 | Raspberry Pi | Raspberry Pi Pico MicroPython firmware (CDC) | [MicroPython Firmware](https://micropython.org/download/rp2-pico/) |
-| 0x0009 | Raspberry Pi | Raspberry Pi Pico SDK CDC UART | [Raspberry Pi Pico SDK](https://raspberrypi.github.io/pico-sdk-doxygen/index.html) |
-| 0x000A | Raspberry Pi | Raspberry Pi Pico SDK CDC UART (RP2040) | [Raspberry Pi Pico SDK](https://raspberrypi.github.io/pico-sdk-doxygen/index.html) |
+| 0x0009 | Raspberry Pi | Raspberry Pi Pico SDK CDC UART | [Raspberry Pi Pico SDK](https://www.raspberrypi.com/documentation/pico-sdk/) |
+| 0x000A | Raspberry Pi | Raspberry Pi Pico SDK CDC UART (RP2040) | [Raspberry Pi Pico SDK](https://www.raspberrypi.com/documentation/pico-sdk/) |
 | 0x000B | Raspberry Pi | Raspberry Pi Pico CircuitPython firmware | [CircuitPython Downloads](https://circuitpython.org/board/raspberry_pi_pico/) |
 | 0x000C | Raspberry Pi | Raspberry Pi RP2040 CMSIS-DAP debug adapter |  |
 | 0x000D | Raspberry Pi | Raspberry Pi USB3HUB ( USB2 hub part) |  |


### PR DESCRIPTION
to skip the GitHub redirect