### PR TITLE
added pcbcupid glyph mini 2040

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -302,3 +302,4 @@ Vendor-ID = 0x2E8A
 | 0x111E | Hubei Quanrong E-Commerce Co., Ltd. |  |  |
 | 0x1120 | Sundial Labs | TLM-110 | https://www.sundiallabs.tech/products/tlm-110-light-flicker-meter?variant=44431835496534 |
 | 0x1121 | KEEB LABORATORY | omni kbd | https://mass-work.github.io/omni_kbd_hp/ |
+| 0x1122 | PCB Cupid | Glyph Mini 2040 | https://shop.pcbcupid.com/product/gdm001 |


### PR DESCRIPTION
This adds support to our open source RP2040 based mini module. 
Product link : https://shop.pcbcupid.com/product/gdm001