### PR TITLE
Add 0x1061 Pixel Pump and update URL for Pixel Pump 2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,7 +136,7 @@ Vendor-ID = 0x2E8A
 | 0x105E | Breadstick Innovations | Raspberry Breadstick | https://github.com/mrangen/RP2040-Breadstick |
 | 0x105F | Invector Labs AB | Challenger RP2040 WiFi6/BLE | https://ilabs.se/challenger-rp2040-wifi6-ble-datasheet/ |
 | 0x1060 | splitkb.com | Liatris | https://splitkb.com/products/liatris |
-| 0x1061 | Robins Tools | Pixel Pump | https://github.com/robin7331/pixel-pump-firmware |
+| 0x1061 | Robins Tools | Pixel Pump | https://robins-tools.com |
 | 0x1063 | Pajenicko s.r.o. | Picopad / Picopad Wifi | picopad.eu |
 | 0x1064 | Union Dynamic | Jackal | https://jtagjackal.io |
 | 0x1065 | WallyWare, inc | MICROpi |  |

--- a/Readme.md
+++ b/Readme.md
@@ -321,7 +321,7 @@ Vendor-ID = 0x2E8A
 | 0x1133 | Yuki Sato (individual developer) | OctGear |  https://studio-juh.github.io/octgear/ |
 | 0x1134 | COMFILE Technology | CUBLOC2 | TBD |
 | 0x1135 | Yawn Labs UG | doppio | wwwn.yawn-labs.com |
-| 0x1137 | Robins Tools | Pixel Pump 2 |  |
+| 0x1137 | Robins Tools | Pixel Pump 2 | https://robins-tools.com |
 | 0x1138 | Orange Music Electronic Co Ltd | ODAC-1 | TBD - Update when released |
 | 0x1139 | IKALOGIC | AT1000 | https://ikalogic.com/test-sequencers/at1000/intro/ |
 | 0x113A | Kelo Guo (individual developer) |  magicKey63 | https://github.com/keloGuo/magicKey63FW |

--- a/Readme.md
+++ b/Readme.md
@@ -136,6 +136,7 @@ Vendor-ID = 0x2E8A
 | 0x105E | Breadstick Innovations | Raspberry Breadstick | https://github.com/mrangen/RP2040-Breadstick |
 | 0x105F | Invector Labs AB | Challenger RP2040 WiFi6/BLE | https://ilabs.se/challenger-rp2040-wifi6-ble-datasheet/ |
 | 0x1060 | splitkb.com | Liatris | https://splitkb.com/products/liatris |
+| 0x1061 | Robins Tools | Pixel Pump | https://github.com/robin7331/pixel-pump-firmware |
 | 0x1063 | Pajenicko s.r.o. | Picopad / Picopad Wifi | picopad.eu |
 | 0x1064 | Union Dynamic | Jackal | https://jtagjackal.io |
 | 0x1065 | WallyWare, inc | MICROpi |  |


### PR DESCRIPTION
Registers PID **0x1061** for the **Pixel Pump (Gen 1)** by Robins Tools — a vacuum pick-and-place tool for PCB assembly, built on the RP2040.

The device uses a vendor-specific HID interface (for host communication with our desktop software) alongside a standard HID keyboard interface, hence the dedicated PID.

The product has been shipping with this PID for a few years; this PR registers it retroactively. Apologies for the delay. Firmware: https://github.com/robin7331/pixel-pump-firmware