### PR TITLE
Add 0x1062: Robins Tools Pixel Pump 2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,6 +136,7 @@ Vendor-ID = 0x2E8A
 | 0x105E | Breadstick Innovations | Raspberry Breadstick | https://github.com/mrangen/RP2040-Breadstick |
 | 0x105F | Invector Labs AB | Challenger RP2040 WiFi6/BLE | https://ilabs.se/challenger-rp2040-wifi6-ble-datasheet/ |
 | 0x1060 | splitkb.com | Liatris | https://splitkb.com/products/liatris |
+| 0x1062 | Robins Tools | Pixel Pump 2 | https://robins-tools.com |
 | 0x1063 | Pajenicko s.r.o. | Picopad / Picopad Wifi | picopad.eu |
 | 0x1064 | Union Dynamic | Jackal | https://jtagjackal.io |
 | 0x1065 | WallyWare, inc | MICROpi |  |


### PR DESCRIPTION
Registers PID **0x1137** for the **Pixel Pump 2** by Robins Tools — the successor to the Pixel Pump (0x1061, see #43), a vacuum pick-and-place tool for PCB assembly, built on the RP2354.

Like its predecessor it uses a vendor-specific HID interface (for host communication with our desktop software) alongside a standard HID keyboard interface, hence the dedicated PID. A separate PID from the Pixel Pump 1 is needed so host software can distinguish the two device generations during discovery.

Product site: https://robins-tools.com

Note: this PR and #43 insert adjacent rows into the same spot in the table. I just filled out the google form a few minutes ago. 